### PR TITLE
Fix: Use proper l5-swagger config key for api-docs.json config

### DIFF
--- a/src/Traits/InteractsWithOpenApi.php
+++ b/src/Traits/InteractsWithOpenApi.php
@@ -50,7 +50,7 @@ trait InteractsWithOpenApi
      */
     protected function getSchemaContents()
     {
-        return file_get_contents(storage_path('api-docs/' . config('l5-swagger.docs_json')));
+        return file_get_contents(storage_path('api-docs/' . config('l5-swagger.documentations.docs_json')));
     }
 
     protected function checkRequesterIsInstantiated(): void


### PR DESCRIPTION
Missed this one in the previous PR 🙃 